### PR TITLE
redefine how request probabilities are computed

### DIFF
--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -60,15 +60,15 @@ def test_crawl():
 
     subcategories = {
         "subCategories": [
-            {"url": subcategory_urls[0]},
-            {"url": subcategory_urls[1]},
+            {"url": subcategory_urls[0], "metadata": {"probability": 0.95}},
+            {"url": subcategory_urls[1], "metadata": {"probability": 0.78}},
         ],
     }
     nextpage = {"nextPage": {"url": nextpage_url}}
     items = {
         "items": [
-            {"url": item_urls[0]},
-            {"url": item_urls[1]},
+            {"url": item_urls[0], "metadata": {"probability": 0.99}},
+            {"url": item_urls[1], "metadata": {"probability": 0.83}},
         ],
     }
 
@@ -86,8 +86,10 @@ def test_crawl():
     assert len(requests) == 2
     assert requests[0].url == subcategory_urls[0]
     assert requests[0].callback == spider.parse_navigation
+    assert requests[0].priority == 95
     assert requests[1].url == subcategory_urls[1]
     assert requests[1].callback == spider.parse_navigation
+    assert requests[1].priority == 78
 
     # subcategories + nextpage
     navigation = ProductNavigation.from_dict(
@@ -102,6 +104,7 @@ def test_crawl():
     urls = {request.url for request in requests}
     assert urls == {*subcategory_urls, nextpage_url}
     assert all(request.callback == spider.parse_navigation for request in requests)
+    assert [request.priority for request in requests] == [100, 95, 78]
 
     # subcategories + nextpage + items
     navigation = ProductNavigation.from_dict(
@@ -120,6 +123,7 @@ def test_crawl():
             assert request.callback == spider.parse_product
         else:
             assert request.callback == spider.parse_navigation
+    assert [request.priority for request in requests] == [199, 183, 100, 95, 78]
 
     # nextpage + items
     navigation = ProductNavigation.from_dict(
@@ -137,6 +141,7 @@ def test_crawl():
     assert requests[1].callback == spider.parse_product
     assert requests[2].url == nextpage_url
     assert requests[2].callback == spider.parse_navigation
+    assert [request.priority for request in requests] == [199, 183, 100]
 
     # subcategories + items
     navigation = ProductNavigation.from_dict(
@@ -156,6 +161,7 @@ def test_crawl():
     assert requests[2].callback == spider.parse_navigation
     assert requests[3].url == subcategory_urls[1]
     assert requests[3].callback == spider.parse_navigation
+    assert [request.priority for request in requests] == [199, 183, 95, 78]
 
     # nextpage
     navigation = ProductNavigation.from_dict(
@@ -168,6 +174,7 @@ def test_crawl():
     assert len(requests) == 1
     assert requests[0].url == nextpage_url
     assert requests[0].callback == spider.parse_navigation
+    assert [request.priority for request in requests] == [100]
 
     # items
     navigation = ProductNavigation.from_dict(
@@ -182,6 +189,7 @@ def test_crawl():
     assert requests[0].callback == spider.parse_product
     assert requests[1].url == item_urls[1]
     assert requests[1].callback == spider.parse_product
+    assert [request.priority for request in requests] == [199, 183]
 
 
 @pytest.mark.parametrize(

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -133,7 +133,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
         if navigation.nextPage:
             yield self.get_parse_navigation_request(
                 navigation.nextPage,
-                priority=self.ITEM_REQUEST_PRIORITY - 1,
+                priority=self._NEXT_PAGE_PRIORITY,
             )
         for request in navigation.subCategories or []:
             if "[heuristics]" in (request.name or ""):


### PR DESCRIPTION
# Overview

This PR proposes to increase the resolution of the request priorities from 10 to 100 bins.

One problem that this tries to address _(although not fully)_ is that subCategory links extracted by ML-models may have 0.90 to 0.94 probabilities even though they're incorrect. On the other hand, good subCategory links tend to have 0.95 to 0.99 probabilities. The issue here is that the way the request probabilities were computed before is that these are binned in the _same_ **request priority = 9.** This means that getting links from the Scheduler _(which uses a priorityQueue)_ would treat these links as being in the same priority level.

Hopefully, in larger crawls, good subCategory links `>= 95` would always be processed and low quality ones `< 95` would lay dormant in the scheduler until the spider has been manually stopped or has reached the max number of items, requests, etc.

Obviously, this wouldn't work when we wait for the spider to exhaust all links.

Lastly, it also ensures that the nextPage link is explicitly higher than any of the subcategory links. This means that we ensure we paginate through categories with actual product links rather than traversing deeply into nestedCategory links that might not have any products _(e.g. some sites have this set up where they don't show you the actual products until you've narrowed down your subCategories to the last level)_.

## Before

Priorities:

- `0` ⎯ normal links
- `0 to 9`  ⎯ subCategory links
- `9` ⎯ nextPage links
- `10` ⎯ item links

## After 

Priorities:

- `0` ⎯ normal links
- `0 to 99` ⎯ subCategory links
- `100` ⎯ nextPage links
- `100 to 199` ⎯ item links

