### PR TITLE
Clarify how max requests work for error responses

### DIFF
--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -385,7 +385,13 @@ def test_metadata():
                     "anyOf": [{"type": "integer"}, {"type": "null"}],
                     "default": None,
                     "title": "Max Requests",
-                    "description": "The max number of Zyte API requests allowed for the crawl.",
+                    "description": (
+                        "The maximum number of Zyte API requests allowed for the crawl.\n"
+                        "\n"
+                        "Requests with error responses that cannot be retried or exceed "
+                        "their retry limit also count here, but they incur in no costs "
+                        "and do not increase the request count in Scrapy Cloud."
+                    ),
                     "widget": "request-limit",
                 },
                 "url": {

--- a/zyte_spider_templates/spiders/base.py
+++ b/zyte_spider_templates/spiders/base.py
@@ -37,7 +37,13 @@ class BaseSpiderParams(BaseModel):
         },
     )
     max_requests: Optional[int] = Field(
-        description="The max number of Zyte API requests allowed for the crawl.",
+        description=(
+            "The maximum number of Zyte API requests allowed for the crawl.\n"
+            "\n"
+            "Requests with error responses that cannot be retried or exceed "
+            "their retry limit also count here, but they incur in no costs "
+            "and do not increase the request count in Scrapy Cloud."
+        ),
         default=None,
         json_schema_extra={
             "widget": "request-limit",


### PR DESCRIPTION
Follow up to https://github.com/scrapy-plugins/scrapy-zyte-api/pull/146

Note that I suspect that the description would render as a single paragraph in the UI, so I am not sure if clarifying this is worth the visual noise.