### PR TITLE
Improve forbidden domain handling

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -70,6 +70,14 @@ The following additional settings are recommended:
     ``"zyte_crawlers.middlewares.CrawlingLogsMiddleware": 1000``, to log crawl
     data in JSON format for debugging purposes.
 
+-   Update :setting:`DOWNLOADER_MIDDLEWARES <scrapy:DOWNLOADER_MIDDLEWARES>` to
+    include
+    ``"zyte_spider_templates.middlewares.ForbiddenDomainDownloaderMiddleware":
+    1100`` and :setting:`SPIDER_MIDDLEWARES <scrapy:SPIDER_MIDDLEWARES>` to
+    include
+    ``"zyte_spider_templates.middlewares.ForbiddenDomainSpiderMiddleware":
+    100``.
+
 For an example of a properly configured ``settings.py`` file, see `the one
 in zyte-spider-templates-project`_.
 


### PR DESCRIPTION
I tested it manually with a raw spider defined on a https://github.com/zytedata/zyte-spider-templates-project project with the 2 setting changes needed:

```python
from zyte_spider_templates import BaseSpider, EcommerceSpider

from pydantic import BaseModel
from scrapy import Request, Spider
from scrapy_spider_metadata import Args


class Params(BaseModel):
    pass


class TestSpider(EcommerceSpider, Args[Params]):
    name = "test"

    @classmethod
    def from_crawler(cls, crawler, *args, **kwargs):
        spider = super(BaseSpider, cls).from_crawler(crawler, *args, **kwargs)
        return spider

    def start_requests(self):
        for url in (
            # Also tested adding an extra, non-forbidden URL.
            "https://forbidden.domain.example",
        ):
            yield Request(
                url=url,
                callback=self.parse_navigation,
            )
```

Should I also figure out a way to test it? It feels like writing the test will take longer than implementing the feature took, so I am not sure whether or not it is worth it. And if we do, should we aim to test both possible close paths (`_maybe_close` calls)? Would tests that create the 2 middlewares and “play” with them work, as opposed to running an actual spider on a mock local website?