### PR TITLE
avoid crawling nextPage if no product links

### DIFF
--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -101,11 +101,11 @@ def test_crawl():
         }
     )
     requests = list(spider.parse_navigation(response, navigation))
-    assert len(requests) == 3
+    assert len(requests) == 2
     urls = {request.url for request in requests}
-    assert urls == {*subcategory_urls, nextpage_url}
+    assert urls == {*subcategory_urls}
     assert all(request.callback == spider.parse_navigation for request in requests)
-    assert [request.priority for request in requests] == [100, 95, 78]
+    assert [request.priority for request in requests] == [95, 78]
 
     # subcategories + nextpage + items
     navigation = ProductNavigation.from_dict(
@@ -172,10 +172,7 @@ def test_crawl():
         }
     )
     requests = list(spider.parse_navigation(response, navigation))
-    assert len(requests) == 1
-    assert requests[0].url == nextpage_url
-    assert requests[0].callback == spider.parse_navigation
-    assert [request.priority for request in requests] == [100]
+    assert len(requests) == 0
 
     # items
     navigation = ProductNavigation.from_dict(

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -153,10 +153,18 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
     ) -> Iterable[Request]:
         page_params = response.meta.get("page_params")
 
-        for request in navigation.items or []:
+        products = navigation.items or []
+        for request in products:
             yield self.get_parse_product_request(request)
+
         if navigation.nextPage:
-            yield self.get_nextpage_request(navigation.nextPage)
+            if not products:
+                self.logger.info(
+                    f"Ignoring nextPage link {navigation.nextPage} since there "
+                    f"are no product links found in {navigation.url}"
+                )
+            else:
+                yield self.get_nextpage_request(navigation.nextPage)
 
         if self.args.crawl_strategy != EcommerceCrawlStrategy.pagination_only:
             for request in navigation.subCategories or []:


### PR DESCRIPTION
This avoids the False Positive results from productNavigation pages where in reality, it's not a productNavigation page but the nextPage has been extracted. Having no product links at all is a good indicator of this False Positivity.

This change should reduce the amount of unnecessary nextPage requests from the spider.