### PR TITLE
remove 'www*.' prefix when parsing allowed_domains

### DIFF
--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -618,3 +618,19 @@ def test_get_parse_navigation_request():
             "page_type": "productNavigation",
         },
     }
+
+
+@pytest.mark.parametrize(
+    "url,allowed_domain",
+    (
+        ("https://example.com", "example.com"),
+        ("https://www.example.com", "example.com"),
+        ("https://www2.example.com", "example.com"),
+    ),
+)
+def test_set_allowed_domains(url, allowed_domain):
+    crawler = get_crawler()
+
+    kwargs = {"url": url}
+    spider = EcommerceSpider.from_crawler(crawler, **kwargs)
+    assert spider.allowed_domains == [allowed_domain]

--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -21,6 +21,7 @@ from zyte_spider_templates.spiders.ecommerce import (
 )
 
 from . import get_crawler
+from .test_utils import URL_TO_DOMAIN
 
 
 def test_parameters():
@@ -620,14 +621,7 @@ def test_get_parse_navigation_request():
     }
 
 
-@pytest.mark.parametrize(
-    "url,allowed_domain",
-    (
-        ("https://example.com", "example.com"),
-        ("https://www.example.com", "example.com"),
-        ("https://www2.example.com", "example.com"),
-    ),
-)
+@pytest.mark.parametrize("url,allowed_domain", URL_TO_DOMAIN)
 def test_set_allowed_domains(url, allowed_domain):
     crawler = get_crawler()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+import pytest
+
+from zyte_spider_templates.utils import get_domain
+
+URL_TO_DOMAIN = (
+    ("https://example.com", "example.com"),
+    ("https://www.example.com", "example.com"),
+    ("https://www2.example.com", "example.com"),
+)
+
+
+@pytest.mark.parametrize("url,domain", URL_TO_DOMAIN)
+def test_get_domain(url, domain):
+    assert get_domain(url) == domain

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,12 @@ URL_TO_DOMAIN = (
     ("https://example.com", "example.com"),
     ("https://www.example.com", "example.com"),
     ("https://www2.example.com", "example.com"),
+    ("https://prefixwww.example.com", "prefixwww.example.com"),
+    ("https://wwworld.example.com", "wwworld.example.com"),
+    ("https://my.wwworld-example.com", "my.wwworld-example.com"),
+    ("https://wwwow.com", "wwwow.com"),
+    ("https://wowww.com", "wowww.com"),
+    ("https://awww.com", "awww.com"),
 )
 
 

--- a/zyte_spider_templates/spiders/base.py
+++ b/zyte_spider_templates/spiders/base.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Optional
 import scrapy
 from pydantic import BaseModel, Field
 from scrapy.crawler import Crawler
-from scrapy.utils.url import parse_url
 
 from zyte_spider_templates._geolocations import (
     GEOLOCATION_OPTIONS_WITH_CODE,
@@ -67,7 +66,6 @@ class BaseSpider(scrapy.Spider):
     @classmethod
     def from_crawler(cls, crawler: Crawler, *args, **kwargs) -> scrapy.Spider:
         spider = super().from_crawler(crawler, *args, **kwargs)
-        spider.allowed_domains = [parse_url(spider.args.url).netloc]
 
         if spider.args.geolocation:
             # We set the geolocation in ZYTE_API_PROVIDER_PARAMS for injected

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -1,9 +1,11 @@
+import re
 from enum import Enum
 from typing import Any, Callable, Dict, Iterable, Optional, Union
 
 import scrapy
 from pydantic import Field
 from scrapy import Request
+from scrapy.utils.url import parse_url
 from scrapy.crawler import Crawler
 from scrapy_poet import DummyResponse
 from scrapy_spider_metadata import Args
@@ -124,6 +126,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
     @classmethod
     def from_crawler(cls, crawler: Crawler, *args, **kwargs) -> scrapy.Spider:
         spider = super(EcommerceSpider, cls).from_crawler(crawler, *args, **kwargs)
+        cls._set_allowed_domains(spider)
 
         if spider.args.extract_from is not None:
             spider.settings.set(
@@ -139,6 +142,12 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
             )
 
         return spider
+
+    @staticmethod
+    def _set_allowed_domains(spider: scrapy.Spider) -> None:
+        allowed_domain = parse_url(spider.args.url).netloc
+        allowed_domain = re.sub("www.*?\.", "", allowed_domain)
+        spider.allowed_domains = [allowed_domain]
 
     def start_requests(self) -> Iterable[Request]:
         page_params = {}

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Dict, Iterable, Optional, Union
 import scrapy
 from pydantic import Field
 from scrapy import Request
-from scrapy.utils.url import parse_url
 from scrapy.crawler import Crawler
+from scrapy.utils.url import parse_url
 from scrapy_poet import DummyResponse
 from scrapy_spider_metadata import Args
 from zyte_common_items import ProbabilityRequest, Product, ProductNavigation
@@ -146,7 +146,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
     @staticmethod
     def _set_allowed_domains(spider: scrapy.Spider) -> None:
         allowed_domain = parse_url(spider.args.url).netloc
-        allowed_domain = re.sub("www.*?\.", "", allowed_domain)
+        allowed_domain = re.sub(r"www.*?\.", "", allowed_domain)
         spider.allowed_domains = [allowed_domain]
 
     def start_requests(self) -> Iterable[Request]:

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -1,4 +1,3 @@
-import re
 from enum import Enum
 from typing import Any, Callable, Dict, Iterable, Optional, Union
 
@@ -6,17 +5,12 @@ import scrapy
 from pydantic import Field
 from scrapy import Request
 from scrapy.crawler import Crawler
-from scrapy.utils.url import parse_url
 from scrapy_poet import DummyResponse
 from scrapy_spider_metadata import Args
 from zyte_common_items import ProbabilityRequest, Product, ProductNavigation
 
 from zyte_spider_templates.documentation import document_enum
-from zyte_spider_templates.spiders.base import (
-    ARG_SETTING_PRIORITY,
-    BaseSpider,
-    BaseSpiderParams,
-)
+from zyte_spider_templates.utils import get_domain
 
 
 @document_enum
@@ -126,7 +120,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
     @classmethod
     def from_crawler(cls, crawler: Crawler, *args, **kwargs) -> scrapy.Spider:
         spider = super(EcommerceSpider, cls).from_crawler(crawler, *args, **kwargs)
-        cls._set_allowed_domains(spider)
+        spider.allowed_domains = [get_domain(spider.args.url)]
 
         if spider.args.extract_from is not None:
             spider.settings.set(
@@ -142,12 +136,6 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
             )
 
         return spider
-
-    @staticmethod
-    def _set_allowed_domains(spider: scrapy.Spider) -> None:
-        allowed_domain = parse_url(spider.args.url).netloc
-        allowed_domain = re.sub(r"www.*?\.", "", allowed_domain)
-        spider.allowed_domains = [allowed_domain]
 
     def start_requests(self) -> Iterable[Request]:
         page_params = {}

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -10,6 +10,11 @@ from scrapy_spider_metadata import Args
 from zyte_common_items import ProbabilityRequest, Product, ProductNavigation
 
 from zyte_spider_templates.documentation import document_enum
+from zyte_spider_templates.spiders.base import (
+    ARG_SETTING_PRIORITY,
+    BaseSpider,
+    BaseSpiderParams,
+)
 from zyte_spider_templates.utils import get_domain
 
 

--- a/zyte_spider_templates/utils.py
+++ b/zyte_spider_templates/utils.py
@@ -4,6 +4,4 @@ from scrapy.utils.url import parse_url
 
 
 def get_domain(url: str) -> str:
-    allowed_domain = parse_url(url).netloc
-    allowed_domain = re.sub(r"www.*?\.", "", allowed_domain)
-    return allowed_domain
+    return re.sub(r"www.*?\.", "", parse_url(url).netloc)

--- a/zyte_spider_templates/utils.py
+++ b/zyte_spider_templates/utils.py
@@ -4,4 +4,4 @@ from scrapy.utils.url import parse_url
 
 
 def get_domain(url: str) -> str:
-    return re.sub(r"www.*?\.", "", parse_url(url).netloc)
+    return re.sub(r"^(www)\d?\.", "", parse_url(url).netloc)

--- a/zyte_spider_templates/utils.py
+++ b/zyte_spider_templates/utils.py
@@ -1,0 +1,9 @@
+import re
+
+from scrapy.utils.url import parse_url
+
+
+def get_domain(url: str) -> str:
+    allowed_domain = parse_url(url).netloc
+    allowed_domain = re.sub(r"www.*?\.", "", allowed_domain)
+    return allowed_domain

--- a/zyte_spider_templates/utils.py
+++ b/zyte_spider_templates/utils.py
@@ -4,4 +4,4 @@ from scrapy.utils.url import parse_url
 
 
 def get_domain(url: str) -> str:
-    return re.sub(r"^(www)\d?\.", "", parse_url(url).netloc)
+    return re.sub(r"^www\d*\.", "", parse_url(url).netloc)


### PR DESCRIPTION
This fixes this specific use case:
* User has entered the parameter: `url=https://www.example.com`.
* This sets `allowed_domains=["www.example.com"]`.
* However, the site lists its links as `https://example.com/some-page` _(without the 'www.' prefix)_
* This causes the `OffsiteMiddleware` to filter out the links.

Removing any 'www*.' prefixes beforehand allows for a cleaner **allowed_domains** value.

The reverse should also work where `url=https://example.com` is used as the arg which sets `allowed_domains=["example.com"]` and the site uses links like `https://www.example.com/some-page`. This is because, the `allowed_domain` would always be a subset of the links in the `OffsiteMiddleware` ([code ref](https://github.com/scrapy/scrapy/blob/master/scrapy/spidermiddlewares/offsite.py#L67-L71)).

Lastly, also moved parsing the **allowed_domains** from the BaseSpider to the EcommerceSpider since ArticleSpider would have a different way to parse them due to multiple seeds.