### PR TITLE
fix `extract_from` spider parameter not working

### DIFF
--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -303,6 +303,37 @@ def test_arguments():
             "getdict",
             {"geolocation": "DE"},
         ),
+        (
+            "extract_from",
+            "browserHtml",
+            "ZYTE_API_PROVIDER_PARAMS",
+            None,
+            "getdict",
+            {
+                "productOptions": {"extractFrom": "browserHtml"},
+                "productNavigationOptions": {"extractFrom": "browserHtml"},
+            },
+        ),
+        (
+            "extract_from",
+            "httpResponseBody",
+            "ZYTE_API_PROVIDER_PARAMS",
+            {"geolocation": "US"},
+            "getdict",
+            {
+                "productOptions": {"extractFrom": "httpResponseBody"},
+                "productNavigationOptions": {"extractFrom": "httpResponseBody"},
+                "geolocation": "US",
+            },
+        ),
+        (
+            "extract_from",
+            None,
+            "ZYTE_API_PROVIDER_PARAMS",
+            {"geolocation": "US"},
+            "getdict",
+            {"geolocation": "US"},
+        ),
     ):
         kwargs = {param: arg}
         settings = {}

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -10,7 +10,11 @@ from scrapy_spider_metadata import Args
 from zyte_common_items import ProbabilityRequest, Product, ProductNavigation
 
 from zyte_spider_templates.documentation import document_enum
-from zyte_spider_templates.spiders.base import BaseSpider, BaseSpiderParams
+from zyte_spider_templates.spiders.base import (
+    ARG_SETTING_PRIORITY,
+    BaseSpider,
+    BaseSpiderParams,
+)
 
 
 @document_enum
@@ -129,7 +133,9 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
                     "productNavigationOptions": {
                         "extractFrom": spider.args.extract_from
                     },
+                    **spider.settings.get("ZYTE_API_PROVIDER_PARAMS", {}),
                 },
+                priority=ARG_SETTING_PRIORITY,
             )
 
         return spider


### PR DESCRIPTION
The problem lies in the `extract_from` spider parameter not working since the `spider.settings.set()` call inside `EcommerceSpider.from_crawler()` doesn't mutate the setting due to the priority value.

Also, even if it did work, it would overwrite the existing `ZYTE_API_PROVIDER_PARAMS` setting that came from either the `BaseSpider` or `settings.py`. 