### PR TITLE
Release notes for 0.7.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 Changes
 =======
 
+0.7.2 (2024-MM-YY)
+------------------
+
+* Implemented :ref:`mixin classes for spider parameters <parameter-mixins>`, to
+  improve reuse.
+
+* Improved docs, providing an example about overriding existing parameters when
+  :ref:`customizing parameters <custom-params>`, and featuring
+  :class:`~web_poet.AnyResponse` in the :ref:`example about overriding parsing
+  <override-parsing>`.
+
+
 0.7.1 (2024-02-22)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-0.7.2 (2024-MM-YY)
+0.7.2 (2024-05-07)
 ------------------
 
 * Implemented :ref:`mixin classes for spider parameters <parameter-mixins>`, to


### PR DESCRIPTION
@VMRuiz requested a release with parameter mixins. I branched out 281f1f5 into [0.7.x](https://github.com/zytedata/zyte-spider-templates/commits/0.7.x) to exclude more recent changes that we don’t want to release yet.