### PR TITLE
Improve UI spider parameter order

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,8 @@
+import pytest
+
+from zyte_spider_templates import BaseSpiderParams
+
+
+def test_deprecation():
+    with pytest.deprecated_call(match="^BaseSpiderParams is deprecated.*"):
+        BaseSpiderParams(url="https://example.com")

--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -437,6 +437,59 @@ def test_metadata():
                     "title": "URLs file",
                     "type": "string",
                 },
+                "crawl_strategy": {
+                    "default": "automatic",
+                    "description": "Determines how the start URL and follow-up URLs are crawled.",
+                    "enumMeta": {
+                        "automatic": {
+                            "description": (
+                                "Automatically use the best crawl strategy based on the given "
+                                "URL inputs. If given a homepage URL, it would attempt to crawl "
+                                "as many products it can discover. Otherwise, it attempt to "
+                                "crawl the products on a given page category."
+                            ),
+                            "title": "Automatic",
+                        },
+                        "direct_item": {
+                            "description": (
+                                "Treat input URLs as direct links to product detail pages, and "
+                                "extract a product from each."
+                            ),
+                            "title": "Direct URLs to Product",
+                        },
+                        "full": {
+                            "description": (
+                                "Follow most links within the domain of URL in an attempt "
+                                "to discover and extract as many products as possible."
+                            ),
+                            "title": "Full",
+                        },
+                        "navigation": {
+                            "description": (
+                                "Follow pagination, subcategories, and product detail "
+                                "pages. Pagination Only is a better choice if the target "
+                                "URL does not have subcategories, or if Zyte API is "
+                                "misidentifying some URLs as subcategories."
+                            ),
+                            "title": "Navigation",
+                        },
+                        "pagination_only": {
+                            "description": (
+                                "Follow pagination and product detail pages. Subcategory links are ignored."
+                            ),
+                            "title": "Pagination Only",
+                        },
+                    },
+                    "title": "Crawl strategy",
+                    "enum": [
+                        "automatic",
+                        "full",
+                        "navigation",
+                        "pagination_only",
+                        "direct_item",
+                    ],
+                    "type": "string",
+                },
                 "geolocation": {
                     "anyOf": [
                         {"type": "string"},
@@ -491,59 +544,6 @@ def test_metadata():
                     },
                     "title": "Extraction source",
                     "enum": ["httpResponseBody", "browserHtml"],
-                },
-                "crawl_strategy": {
-                    "default": "automatic",
-                    "description": "Determines how the start URL and follow-up URLs are crawled.",
-                    "enumMeta": {
-                        "automatic": {
-                            "description": (
-                                "Automatically use the best crawl strategy based on the given "
-                                "URL inputs. If given a homepage URL, it would attempt to crawl "
-                                "as many products it can discover. Otherwise, it attempt to "
-                                "crawl the products on a given page category."
-                            ),
-                            "title": "Automatic",
-                        },
-                        "direct_item": {
-                            "description": (
-                                "Treat input URLs as direct links to product detail pages, and "
-                                "extract a product from each."
-                            ),
-                            "title": "Direct URLs to Product",
-                        },
-                        "full": {
-                            "description": (
-                                "Follow most links within the domain of URL in an attempt "
-                                "to discover and extract as many products as possible."
-                            ),
-                            "title": "Full",
-                        },
-                        "navigation": {
-                            "description": (
-                                "Follow pagination, subcategories, and product detail "
-                                "pages. Pagination Only is a better choice if the target "
-                                "URL does not have subcategories, or if Zyte API is "
-                                "misidentifying some URLs as subcategories."
-                            ),
-                            "title": "Navigation",
-                        },
-                        "pagination_only": {
-                            "description": (
-                                "Follow pagination and product detail pages. Subcategory links are ignored."
-                            ),
-                            "title": "Pagination Only",
-                        },
-                    },
-                    "title": "Crawl strategy",
-                    "enum": [
-                        "automatic",
-                        "full",
-                        "navigation",
-                        "pagination_only",
-                        "direct_item",
-                    ],
-                    "type": "string",
                 },
             },
             "title": "EcommerceSpiderParams",

--- a/zyte_spider_templates/params.py
+++ b/zyte_spider_templates/params.py
@@ -83,19 +83,21 @@ class MaxRequestsParam(BaseModel):
     )
 
 
-INPUT_FIELDS = ("url", "urls", "urls_file")
+INPUT_GROUP_FIELDS = ("url", "urls", "urls_file")
 INPUT_GROUP = {
     "id": "inputs",
     "title": "Inputs",
-    "description": ("Input data that determines the start URLs of the crawl."),
+    "description": "Input data that determines the start URLs of the crawl.",
     "widget": "exclusive",
 }
 
 
-def single_input_validator(model):
-    input_fields = set(field for field in INPUT_FIELDS if getattr(model, field, None))
+def validate_input_group(model):
+    input_fields = set(
+        field for field in INPUT_GROUP_FIELDS if getattr(model, field, None)
+    )
     if not input_fields:
-        input_field_list = ", ".join(INPUT_FIELDS)
+        input_field_list = ", ".join(INPUT_GROUP_FIELDS)
         raise ValueError(
             f"No input parameter defined. Please, define one of: "
             f"{input_field_list}."
@@ -128,8 +130,8 @@ class UrlsFileParam(BaseModel):
     )
 
     @model_validator(mode="after")
-    def single_input(self):
-        return single_input_validator(self)
+    def input_group(self):
+        return validate_input_group(self)
 
 
 class UrlParam(BaseModel):
@@ -146,8 +148,8 @@ class UrlParam(BaseModel):
     )
 
     @model_validator(mode="after")
-    def single_input(self):
-        return single_input_validator(self)
+    def input_group(self):
+        return validate_input_group(self)
 
 
 class UrlsParam(BaseModel):
@@ -167,8 +169,8 @@ class UrlsParam(BaseModel):
     )
 
     @model_validator(mode="after")
-    def single_input(self):
-        return single_input_validator(self)
+    def input_group(self):
+        return validate_input_group(self)
 
     @field_validator("urls", mode="before")
     @classmethod

--- a/zyte_spider_templates/params.py
+++ b/zyte_spider_templates/params.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic.config import JsonDict
 
 from zyte_spider_templates._geolocations import (
     GEOLOCATION_OPTIONS_WITH_CODE,
@@ -84,7 +85,7 @@ class MaxRequestsParam(BaseModel):
 
 
 INPUT_GROUP_FIELDS = ("url", "urls", "urls_file")
-INPUT_GROUP = {
+INPUT_GROUP: JsonDict = {
     "id": "inputs",
     "title": "Inputs",
     "description": "Input data that determines the start URLs of the crawl.",

--- a/zyte_spider_templates/params.py
+++ b/zyte_spider_templates/params.py
@@ -5,7 +5,12 @@ from logging import getLogger
 from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from pydantic.config import JsonDict
+
+try:
+    from pydantic.config import JsonDict
+except ImportError:
+    JsonValue = Union[int, float, str, bool, None, List["JsonValue"], "JsonDict"]
+    JsonDict = Dict[str, JsonValue]
 
 from zyte_spider_templates._geolocations import (
     GEOLOCATION_OPTIONS_WITH_CODE,

--- a/zyte_spider_templates/params.py
+++ b/zyte_spider_templates/params.py
@@ -10,7 +10,7 @@ try:
     from pydantic.config import JsonDict
 except ImportError:
     JsonValue = Union[int, float, str, bool, None, List["JsonValue"], "JsonDict"]
-    JsonDict = Dict[str, JsonValue]
+    JsonDict = Dict[str, JsonValue]  # type: ignore[misc]
 
 from zyte_spider_templates._geolocations import (
     GEOLOCATION_OPTIONS_WITH_CODE,

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Iterable, Optional, Union
 
 import requests
 import scrapy
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from scrapy import Request
 from scrapy.crawler import Crawler
 from scrapy_poet import DummyResponse
@@ -13,12 +13,20 @@ from zyte_common_items import ProbabilityRequest, Product, ProductNavigation
 from zyte_spider_templates.heuristics import is_homepage
 from zyte_spider_templates.spiders.base import (
     ARG_SETTING_PRIORITY,
+    INPUT_GROUP,
     BaseSpider,
-    BaseSpiderParams,
 )
 from zyte_spider_templates.utils import get_domain
 
 from ..documentation import document_enum
+from ..params import (
+    ExtractFromParam,
+    GeolocationParam,
+    MaxRequestsParam,
+    UrlParam,
+    UrlsFileParam,
+    UrlsParam,
+)
 from ..utils import load_url_list
 
 
@@ -102,8 +110,23 @@ class EcommerceCrawlStrategyParam(BaseModel):
     )
 
 
-class EcommerceSpiderParams(EcommerceCrawlStrategyParam, BaseSpiderParams):
-    pass
+class EcommerceSpiderParams(
+    ExtractFromParam,
+    MaxRequestsParam,
+    GeolocationParam,
+    EcommerceCrawlStrategyParam,
+    UrlsFileParam,
+    UrlsParam,
+    UrlParam,
+    BaseModel,
+):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "groups": [
+                INPUT_GROUP,
+            ],
+        },
+    )
 
 
 class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):


### PR DESCRIPTION
Gives `crawl_strategy` a more logical order among EcommerceSpider parameters, deprecating `BaseSpiderParams` in the process. Less code reuse in exchange for more flexibility for a better no-code experience. 