### PR TITLE
Drop Python 3.8 support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: '3.8'
+        - python-version: '3.9'
           toxenv: min
-        - python-version: '3.8'
         - python-version: '3.9'
         - python-version: '3.10'
         - python-version: '3.11'

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -16,7 +16,7 @@ configured on an existing Scrapy_ project.
 Requirements
 ============
 
--   Python 3.8+
+-   Python 3.9+
 
 -   Scrapy 2.11+
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     {posargs:zyte_spider_templates tests}
 
 [testenv:min]
-basepython = python3.8
+basepython = python3.9
 deps =
     {[testenv]deps}
     pydantic==2


### PR DESCRIPTION
To prepare for merging of `typing.Annotated` code.