### PR TITLE
Google Search: results per page

### DIFF
--- a/tests/test_serp.py
+++ b/tests/test_serp.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 import pytest
 from pydantic import ValidationError
 from scrapy import Request
@@ -9,6 +11,44 @@ from zyte_spider_templates.spiders.serp import GoogleSearchSpider
 
 from . import get_crawler
 from .utils import assertEqualSpiderMetadata
+
+
+def run_parse_serp(spider, total_results=99999, page=1, query="foo"):
+    url = f"https://www.google.com/search?q={quote_plus(query)}"
+    if page > 1:
+        url = add_or_replace_parameter(url, "start", (page - 1) * 10)
+    response = ZyteAPITextResponse.from_api_response(
+        api_response={
+            "serp": {
+                "organicResults": [
+                    {
+                        "description": "…",
+                        "name": "…",
+                        "url": f"https://example.com/{rank}",
+                        "rank": rank,
+                    }
+                    for rank in range(1, 11)
+                ],
+                "metadata": {
+                    "dateDownloaded": "2024-10-25T08:59:45Z",
+                    "displayedQuery": query,
+                    "searchedQuery": query,
+                    "totalOrganicResults": total_results,
+                },
+                "pageNumber": page,
+                "url": url,
+            },
+            "url": url,
+        },
+    )
+    items = []
+    requests = []
+    for item_or_request in spider.parse_serp(response, page_number=page):
+        if isinstance(item_or_request, Request):
+            requests.append(item_or_request)
+        else:
+            items.append(item_or_request)
+    return items, requests
 
 
 def test_parameters():
@@ -259,6 +299,13 @@ def test_metadata():
                     "title": "Max Pages",
                     "type": "integer",
                 },
+                "results_per_page": {
+                    "default": 10,
+                    "description": "Maximum number of results per page.",
+                    "minimum": 1,
+                    "title": "Results Per Page",
+                    "type": "integer",
+                },
                 "max_requests": {
                     "anyOf": [{"type": "integer"}, {"type": "null"}],
                     "default": 100,
@@ -321,51 +368,17 @@ def test_pagination():
     crawler = get_crawler()
     spider = GoogleSearchSpider.from_crawler(crawler, search_queries="foo bar")
 
-    def run_parse_serp(total_results, page=1):
-        url = "https://www.google.com/search?q=foo+bar"
-        if page > 1:
-            url = add_or_replace_parameter(url, "start", (page - 1) * 10)
-        response = ZyteAPITextResponse.from_api_response(
-            api_response={
-                "serp": {
-                    "organicResults": [
-                        {
-                            "description": "…",
-                            "name": "…",
-                            "url": f"https://example.com/{rank}",
-                            "rank": rank,
-                        }
-                        for rank in range(1, 11)
-                    ],
-                    "metadata": {
-                        "dateDownloaded": "2024-10-25T08:59:45Z",
-                        "displayedQuery": "foo bar",
-                        "searchedQuery": "foo bar",
-                        "totalOrganicResults": total_results,
-                    },
-                    "pageNumber": page,
-                    "url": url,
-                },
-                "url": url,
-            },
-        )
-        items = []
-        requests = []
-        for item_or_request in spider.parse_serp(response, page_number=page):
-            if isinstance(item_or_request, Request):
-                requests.append(item_or_request)
-            else:
-                items.append(item_or_request)
-        return items, requests
-
     items, requests = run_parse_serp(
+        spider,
         total_results=10,
     )
     assert len(items) == 1
     assert len(requests) == 0
 
     items, requests = run_parse_serp(
+        spider,
         total_results=11,
+        query="foo bar",
     )
     assert len(items) == 1
     assert len(requests) == 1
@@ -373,15 +386,19 @@ def test_pagination():
     assert requests[0].cb_kwargs["page_number"] == 2
 
     items, requests = run_parse_serp(
+        spider,
         total_results=20,
         page=2,
+        query="foo bar",
     )
     assert len(items) == 1
     assert len(requests) == 0
 
     items, requests = run_parse_serp(
+        spider,
         total_results=21,
         page=2,
+        query="foo bar",
     )
     assert len(items) == 1
     assert len(requests) == 1
@@ -445,3 +462,26 @@ def test_parse_serp():
     # The page_number parameter is required.
     with pytest.raises(TypeError):
         spider.parse_serp(response)
+
+
+def test_results_per_page():
+    crawler = get_crawler()
+    spider = GoogleSearchSpider.from_crawler(
+        crawler, search_queries="foo", results_per_page=1
+    )
+    requests = list(spider.start_requests())
+    assert len(requests) == 1
+    assert requests[0].url == "https://www.google.com/search?q=foo&num=1"
+
+    items, requests = run_parse_serp(spider)
+    assert len(items) == 1
+    assert len(requests) == 1
+    assert requests[0].url == "https://www.google.com/search?q=foo&start=1&num=1"
+
+
+def test_results_per_page_min():
+    crawler = get_crawler()
+    with pytest.raises(ValidationError):
+        GoogleSearchSpider.from_crawler(
+            crawler, search_queries="foo", results_per_page=0
+        )

--- a/tests/test_serp.py
+++ b/tests/test_serp.py
@@ -300,11 +300,18 @@ def test_metadata():
                     "type": "integer",
                 },
                 "results_per_page": {
-                    "default": 10,
+                    "anyOf": [
+                        {
+                            "minimum": 1,
+                            "type": "integer",
+                        },
+                        {
+                            "type": "null",
+                        },
+                    ],
+                    "default": None,
                     "description": "Maximum number of results per page.",
-                    "minimum": 1,
                     "title": "Results Per Page",
-                    "type": "integer",
                 },
                 "max_requests": {
                     "anyOf": [{"type": "integer"}, {"type": "null"}],


### PR DESCRIPTION
To do:
- [x] Test that `ge=1` works on Scrapy Cloud, as this is the first time I recall using that in an optional field, and the UI may not support that.