### PR TITLE
Do not let request-building exceptions break crawling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -48,6 +48,8 @@ class DefaultResource(Resource):
 
     When product or productList is requested, an item with the current URL is
     always returned.
+
+    All output also includes invalid links (mailto:…).
     """
 
     def getChild(self, path, request):
@@ -69,7 +71,7 @@ class DefaultResource(Resource):
         response_data["url"] = request_data["url"]
 
         non_navigation_url = "https://example.com/non-navigation"
-        html = f"""<html><body><a href="{non_navigation_url}"></a></body></html>"""
+        html = f"""<html><body><a href="{non_navigation_url}"></a><a href="mailto:jane@example.com"></a></body></html>"""
         if request_data.get("browserHtml", False) is True:
             response_data["browserHtml"] = html
 
@@ -94,11 +96,15 @@ class DefaultResource(Resource):
                 }
                 if "/category/" not in request_data["url"]:
                     kwargs["subCategories"] = [
+                        {"url": "mailto:jane@example.com"},
                         {"url": f"{request_data['url'].rstrip('/')}/category/1"},
                     ]
+            else:
+                kwargs["nextPage"] = {"url": "mailto:jane@example.com"}
             response_data["productNavigation"] = {
                 "url": request_data["url"],
                 "items": [
+                    {"url": "mailto:jane@example.com"},
                     {"url": f"{request_data['url'].rstrip('/')}/product/1"},
                     {"url": f"{request_data['url'].rstrip('/')}/product/2"},
                 ],

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -49,7 +49,7 @@ class DefaultResource(Resource):
     When product or productList is requested, an item with the current URL is
     always returned.
 
-    All output also includes invalid links (mailto:…).
+    All output also includes unsupported links (mailto:…).
     """
 
     def getChild(self, path, request):

--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -68,6 +68,8 @@ def test_start_requests_crawling_logs_page_type():
 
 
 def test_crawl():
+    crawler = get_crawler()
+
     subcategory_urls = [
         "https://example.com/category/tech",
         "https://example.com/category/books",
@@ -95,7 +97,7 @@ def test_crawl():
     }
 
     url = subcategory_urls[0]
-    spider = EcommerceSpider(url="https://example.com/")
+    spider = EcommerceSpider.from_crawler(crawler, url="https://example.com/")
 
     def _get_requests(navigation: ProductNavigation) -> List[scrapy.Request]:
         return list(
@@ -219,8 +221,8 @@ def test_crawl():
     assert [request.priority for request in requests] == [199, 183]
 
     # Test parse_navigation() behavior on pagination_only crawl strategy.
-    spider = EcommerceSpider(
-        url="https://example.com/", crawl_strategy="pagination_only"
+    spider = EcommerceSpider.from_crawler(
+        crawler, url="https://example.com/", crawl_strategy="pagination_only"
     )
 
     # nextpage + items

--- a/tests/test_job_posting.py
+++ b/tests/test_job_posting.py
@@ -49,6 +49,7 @@ def test_start_requests():
 
 
 def test_crawl():
+    crawler = get_crawler()
     url = "https://example.com/category/tech"
     nextpage_url = "https://example.com/category/tech?p=2"
     item_urls = [
@@ -65,7 +66,7 @@ def test_crawl():
             {"url": item_urls[1], "metadata": {"probability": 0.83}},
         ],
     }
-    spider = JobPostingSpider(url="https://example.com/")
+    spider = JobPostingSpider.from_crawler(crawler, url="https://example.com/")
 
     # no links found
     navigation = JobPostingNavigation.from_dict({"url": url})

--- a/zyte_spider_templates/spiders/article.py
+++ b/zyte_spider_templates/spiders/article.py
@@ -286,7 +286,7 @@ class ArticleSpider(Args[ArticleSpiderParams], BaseSpider):
 
         for url in self.start_urls:
             meta = {"request_type": request_type}
-            with self._log_exception:
+            with self._log_request_exception:
                 yield self.get_parse_request(
                     ProbabilityRequest(
                         url=url,
@@ -330,7 +330,7 @@ class ArticleSpider(Args[ArticleSpiderParams], BaseSpider):
                     "request_type": RequestType.NEXT_PAGE,
                     "increase_navigation_depth": False,
                 }
-                with self._log_exception:
+                with self._log_request_exception:
                     yield self.get_parse_request(
                         navigation.nextPage, meta=meta, is_feed=False
                     )
@@ -377,7 +377,7 @@ class ArticleSpider(Args[ArticleSpiderParams], BaseSpider):
                 "increase_navigation_depth": increase_navigation_depth,
             }
 
-            with self._log_exception:
+            with self._log_request_exception:
                 yield self.get_parse_request(req, meta=meta, is_feed=is_feed)
 
     def get_parse_request(

--- a/zyte_spider_templates/spiders/article.py
+++ b/zyte_spider_templates/spiders/article.py
@@ -286,15 +286,16 @@ class ArticleSpider(Args[ArticleSpiderParams], BaseSpider):
 
         for url in self.start_urls:
             meta = {"request_type": request_type}
-            yield self.get_parse_request(
-                ProbabilityRequest(
-                    url=url,
-                    name=f"[{request_type.value.name}]",
-                    metadata=ProbabilityMetadata(probability=probability),
-                ),
-                meta=meta,
-                is_feed=False,
-            )
+            with self._log_exception:
+                yield self.get_parse_request(
+                    ProbabilityRequest(
+                        url=url,
+                        name=f"[{request_type.value.name}]",
+                        metadata=ProbabilityMetadata(probability=probability),
+                    ),
+                    meta=meta,
+                    is_feed=False,
+                )
 
     def parse_dynamic(
         self,
@@ -329,9 +330,10 @@ class ArticleSpider(Args[ArticleSpiderParams], BaseSpider):
                     "request_type": RequestType.NEXT_PAGE,
                     "increase_navigation_depth": False,
                 }
-                yield self.get_parse_request(
-                    navigation.nextPage, meta=meta, is_feed=False
-                )
+                with self._log_exception:
+                    yield self.get_parse_request(
+                        navigation.nextPage, meta=meta, is_feed=False
+                    )
 
         subcategories = navigation.subCategories or []
         items = navigation.items or []
@@ -375,7 +377,8 @@ class ArticleSpider(Args[ArticleSpiderParams], BaseSpider):
                 "increase_navigation_depth": increase_navigation_depth,
             }
 
-            yield self.get_parse_request(req, meta=meta, is_feed=is_feed)
+            with self._log_exception:
+                yield self.get_parse_request(req, meta=meta, is_feed=is_feed)
 
     def get_parse_request(
         self,

--- a/zyte_spider_templates/spiders/base.py
+++ b/zyte_spider_templates/spiders/base.py
@@ -26,17 +26,21 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-class _LogExceptionContextManager:
-    def __init__(self, spider):
+class _LogExceptionsContextManager:
+    def __init__(self, spider, exc_info):
         self._spider = spider
+        self._exc_info = exc_info
 
     def __enter__(self):
         return
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        if exc_type is not None:
+        if exc_type is None:
+            return True
+        if issubclass(exc_type, self._exc_info):
             self._spider.logger.exception(exc_value)
-        return True
+            return True
+        return False
 
 
 # Higher priority than command-line-defined settings (40).
@@ -89,7 +93,7 @@ class BaseSpider(scrapy.Spider):
     _NEXT_PAGE_PRIORITY: int = 100
 
     _custom_attrs_dep = None
-    _log_exception: _LogExceptionContextManager = None  # type: ignore[assignment]
+    _log_request_exception: _LogExceptionsContextManager = None  # type: ignore[assignment]
 
     @classmethod
     def from_crawler(cls, crawler: Crawler, *args, **kwargs) -> Self:
@@ -135,6 +139,6 @@ class BaseSpider(scrapy.Spider):
                 custom_attrs(custom_attrs_input, custom_attrs_options),
             ]
 
-        spider._log_exception = _LogExceptionContextManager(spider)
+        spider._log_request_exception = _LogExceptionsContextManager(spider, ValueError)
 
         return spider

--- a/zyte_spider_templates/spiders/base.py
+++ b/zyte_spider_templates/spiders/base.py
@@ -89,6 +89,7 @@ class BaseSpider(scrapy.Spider):
     _NEXT_PAGE_PRIORITY: int = 100
 
     _custom_attrs_dep = None
+    _log_exception: _LogExceptionContextManager = None  # type: ignore[assignment]
 
     @classmethod
     def from_crawler(cls, crawler: Crawler, *args, **kwargs) -> Self:

--- a/zyte_spider_templates/spiders/base.py
+++ b/zyte_spider_templates/spiders/base.py
@@ -26,6 +26,19 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
+class _LogExceptionContextManager:
+    def __init__(self, spider):
+        self._spider = spider
+
+    def __enter__(self):
+        return
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if exc_type is not None:
+            self._spider.logger.exception(exc_value)
+        return True
+
+
 # Higher priority than command-line-defined settings (40).
 ARG_SETTING_PRIORITY: int = 50
 
@@ -120,5 +133,7 @@ class BaseSpider(scrapy.Spider):
                 CustomAttributes,
                 custom_attrs(custom_attrs_input, custom_attrs_options),
             ]
+
+        spider._log_exception = _LogExceptionContextManager(spider)
 
         return spider

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -321,7 +321,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
                 }
                 if self.args.extract_from == ExtractFrom.browserHtml:
                     meta["inject"] = [BrowserResponse]
-                with self._log_exception:
+                with self._log_request_exception:
                     yield scrapy.Request(
                         url=url,
                         callback=self.parse_search_request_template,
@@ -329,7 +329,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
                     )
         else:
             for url in self.start_urls:
-                with self._log_exception:
+                with self._log_request_exception:
                     yield self.get_start_request(url)
 
     def parse_search_request_template(
@@ -349,7 +349,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
                 meta["inject"] = [ProductList]
                 if self._custom_attrs_dep:
                     meta["inject"].append(self._custom_attrs_dep)
-            with self._log_exception:
+            with self._log_request_exception:
                 yield search_request_template.request(query=query).to_scrapy(
                     callback=self.parse_navigation,
                     meta=meta,
@@ -374,7 +374,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
         products = navigation.items or []
         if self.args.extract == EcommerceExtract.product:
             for request in products:
-                with self._log_exception:
+                with self._log_request_exception:
                     yield self.get_parse_product_request(request)
 
         if (
@@ -387,7 +387,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
                     f"are no product links found in {navigation.url}"
                 )
             else:
-                with self._log_exception:
+                with self._log_request_exception:
                     yield self.get_nextpage_request(
                         cast(ProbabilityRequest, navigation.nextPage)
                     )
@@ -401,7 +401,7 @@ class EcommerceSpider(Args[EcommerceSpiderParams], BaseSpider):
             and not self.args.search_queries
         ):
             for request in navigation.subCategories or []:
-                with self._log_exception:
+                with self._log_request_exception:
                     yield self.get_subcategory_request(request, page_params=page_params)
 
         if self.args.extract == EcommerceExtract.productList:

--- a/zyte_spider_templates/spiders/job_posting.py
+++ b/zyte_spider_templates/spiders/job_posting.py
@@ -174,14 +174,16 @@ class JobPostingSpider(Args[JobPostingSpiderParams], BaseSpider):
 
     def start_requests(self) -> Iterable[scrapy.Request]:
         for url in self.start_urls:
-            yield self.get_start_request(url)
+            with self._log_exception:
+                yield self.get_start_request(url)
 
     def parse_navigation(
         self, response: DummyResponse, navigation: JobPostingNavigation
     ) -> Iterable[scrapy.Request]:
         job_postings = navigation.items or []
         for request in job_postings:
-            yield self.get_parse_job_posting_request(request)
+            with self._log_exception:
+                yield self.get_parse_job_posting_request(request)
 
         if navigation.nextPage:
             if not job_postings:
@@ -190,9 +192,10 @@ class JobPostingSpider(Args[JobPostingSpiderParams], BaseSpider):
                     f"are no job posting links found in {navigation.url}"
                 )
             else:
-                yield self.get_nextpage_request(
-                    cast(ProbabilityRequest, navigation.nextPage)
-                )
+                with self._log_exception:
+                    yield self.get_nextpage_request(
+                        cast(ProbabilityRequest, navigation.nextPage)
+                    )
 
     def parse_job_posting(
         self, response: DummyResponse, job_posting: JobPosting, dynamic: DynamicDeps

--- a/zyte_spider_templates/spiders/job_posting.py
+++ b/zyte_spider_templates/spiders/job_posting.py
@@ -174,7 +174,7 @@ class JobPostingSpider(Args[JobPostingSpiderParams], BaseSpider):
 
     def start_requests(self) -> Iterable[scrapy.Request]:
         for url in self.start_urls:
-            with self._log_exception:
+            with self._log_request_exception:
                 yield self.get_start_request(url)
 
     def parse_navigation(
@@ -182,7 +182,7 @@ class JobPostingSpider(Args[JobPostingSpiderParams], BaseSpider):
     ) -> Iterable[scrapy.Request]:
         job_postings = navigation.items or []
         for request in job_postings:
-            with self._log_exception:
+            with self._log_request_exception:
                 yield self.get_parse_job_posting_request(request)
 
         if navigation.nextPage:
@@ -192,7 +192,7 @@ class JobPostingSpider(Args[JobPostingSpiderParams], BaseSpider):
                     f"are no job posting links found in {navigation.url}"
                 )
             else:
-                with self._log_exception:
+                with self._log_request_exception:
                     yield self.get_nextpage_request(
                         cast(ProbabilityRequest, navigation.nextPage)
                     )

--- a/zyte_spider_templates/spiders/serp.py
+++ b/zyte_spider_templates/spiders/serp.py
@@ -317,7 +317,7 @@ class GoogleSearchSpider(Args[GoogleSearchSpiderParams], BaseSpider):
         url = f"https://www.{self.args.domain.value}/search"
         for search_query in search_queries:
             search_url = add_or_replace_parameter(url, "q", search_query)
-            with self._log_exception:
+            with self._log_request_exception:
                 yield self.get_serp_request(search_url, page_number=1)
 
     def parse_serp(self, response, page_number) -> Iterable[Union[Request, Serp]]:
@@ -332,7 +332,7 @@ class GoogleSearchSpider(Args[GoogleSearchSpiderParams], BaseSpider):
                 or serp.metadata.totalOrganicResults > next_start
             ):
                 next_url = add_or_replace_parameter(serp.url, "start", str(next_start))
-                with self._log_exception:
+                with self._log_request_exception:
                     yield self.get_serp_request(next_url, page_number=page_number + 1)
 
         if self.args.item_type is None:
@@ -340,7 +340,7 @@ class GoogleSearchSpider(Args[GoogleSearchSpiderParams], BaseSpider):
             return
 
         for result in serp.organicResults:
-            with self._log_exception:
+            with self._log_request_exception:
                 yield response.follow(
                     result.url,
                     callback=self.parse_result,


### PR DESCRIPTION
Created a context manager to capture and log exceptions, and used it in every spider when building a request object, so that any exception from request building does not prevent the rest of the callback code from running normally.

Built on top of https://github.com/zytedata/zyte-spider-templates/pull/92 because the mockserver makes testing this change really easy (most of those tests failed upon adding those mailto: links, and work after the changes here).