### PR TITLE
Extend the Search Queries description

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:

--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -680,7 +680,13 @@ def test_metadata():
                     "default": [],
                     "description": (
                         "A list of search queries, one per line, to submit "
-                        "using the search form found on each input URL."
+                        "using the search form found on each input URL. Only "
+                        "works for input URLs that support search. May not "
+                        "work on every website. Search queries are not "
+                        'compatible with the "full" and "navigation" '
+                        "crawl strategies, and when extracting products, they "
+                        'are not compatible with the "direct_item" crawl '
+                        "strategy either."
                     ),
                     "items": {"type": "string"},
                     "title": "Search Queries",

--- a/zyte_spider_templates/spiders/ecommerce.py
+++ b/zyte_spider_templates/spiders/ecommerce.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    List,
     Optional,
     TypeVar,
     Union,
@@ -186,6 +187,25 @@ class EcommerceExtractParam(BaseModel):
     )
 
 
+class EcommerceSearchQueriesParam(SearchQueriesParam):
+    search_queries: List[str] = Field(
+        title="Search Queries",
+        description=(
+            "A list of search queries, one per line, to submit using the "
+            "search form found on each input URL. Only works for input URLs "
+            "that support search. May not work on every website. Search "
+            'queries are not compatible with the "full" and "navigation" '
+            "crawl strategies, and when extracting products, they are not "
+            'compatible with the "direct_item" crawl strategy either.'
+        ),
+        default_factory=list,
+        json_schema_extra={
+            "default": [],
+            "widget": "textarea",
+        },
+    )
+
+
 class EcommerceSpiderParams(
     CustomAttrsMethodParam,
     CustomAttrsInputParam,
@@ -194,7 +214,7 @@ class EcommerceSpiderParams(
     GeolocationParam,
     EcommerceCrawlStrategyParam,
     EcommerceExtractParam,
-    SearchQueriesParam,
+    EcommerceSearchQueriesParam,
     UrlsFileParam,
     UrlsParam,
     UrlParam,


### PR DESCRIPTION
Built on top of #92 because it assumes `productList` is supported.