### PR TITLE
Mark job posting template as experimental

### DIFF
--- a/tests/test_job_posting.py
+++ b/tests/test_job_posting.py
@@ -265,7 +265,7 @@ def test_metadata():
     expected_metadata = {
         "template": True,
         "title": "Job posting",
-        "description": "Template for spiders that extract job posting data from websites.",
+        "description": "[Experimental] Template for spiders that extract job posting data from websites.",
         "param_schema": {
             "groups": [
                 {

--- a/zyte_spider_templates/spiders/job_posting.py
+++ b/zyte_spider_templates/spiders/job_posting.py
@@ -109,7 +109,7 @@ class JobPostingSpider(Args[JobPostingSpiderParams], BaseSpider):
     metadata: Dict[str, Any] = {
         **BaseSpider.metadata,
         "title": "Job posting",
-        "description": "Template for spiders that extract job posting data from websites.",
+        "description": "[Experimental] Template for spiders that extract job posting data from websites.",
     }
 
     @classmethod


### PR DESCRIPTION
It is useful as-is, but there are known issues - e.g. JS pagination is common on job websites, and it's not handled by the spider, so on many websites it can only extract jobs from the first page.