### PR TITLE
Fix _replace_builtin

### DIFF
--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -72,7 +72,7 @@ def _test_setting_changes(initial_settings, expected_settings):
                 "DOWNLOADER_MIDDLEWARES": {
                     MaxRequestsPerSeedDownloaderMiddleware: 100,
                     BUILTIN_OFFSITE_MIDDLEWARE_IMPORT_PATH: None,
-                    AllowOffsiteMiddleware: 500,
+                    AllowOffsiteMiddleware: 50,
                 },
                 "SCHEDULER_DISK_QUEUE": "scrapy.squeues.PickleFifoDiskQueue",
                 "SCHEDULER_MEMORY_QUEUE": "scrapy.squeues.FifoMemoryQueue",

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -19,10 +19,14 @@ _crawler = get_crawler()
 BASELINE_SETTINGS = _crawler.settings.copy_to_dict()
 
 try:
-    from scrapy.downloadermiddlewares.offsite import OffsiteMiddleware
+    from scrapy.downloadermiddlewares.offsite import OffsiteMiddleware  # noqa: F401
 except ImportError:
-    from scrapy.spidermiddlewares.offsite import (  # type: ignore[assignment]
-        OffsiteMiddleware,
+    BUILTIN_OFFSITE_MIDDLEWARE_IMPORT_PATH = (
+        "scrapy.spidermiddlewares.offsite.OffsiteMiddleware"
+    )
+else:
+    BUILTIN_OFFSITE_MIDDLEWARE_IMPORT_PATH = (
+        "scrapy.downloadermiddlewares.offsite.OffsiteMiddleware"
     )
 
 
@@ -67,7 +71,7 @@ def _test_setting_changes(initial_settings, expected_settings):
                 "CLOSESPIDER_TIMEOUT_NO_ITEM": 600,
                 "DOWNLOADER_MIDDLEWARES": {
                     MaxRequestsPerSeedDownloaderMiddleware: 100,
-                    OffsiteMiddleware: None,
+                    BUILTIN_OFFSITE_MIDDLEWARE_IMPORT_PATH: None,
                     AllowOffsiteMiddleware: 500,
                 },
                 "SCHEDULER_DISK_QUEUE": "scrapy.squeues.PickleFifoDiskQueue",
@@ -128,7 +132,7 @@ def test_poet_setting_changes_since_scrapy_2_11_2(initial_settings, expected_set
                     OffsiteRequestsPerSeedMiddleware: 49,
                     OnlyFeedsMiddleware: 108,
                     TrackNavigationDepthSpiderMiddleware: 110,
-                    OffsiteMiddleware: None,
+                    BUILTIN_OFFSITE_MIDDLEWARE_IMPORT_PATH: None,
                     AllowOffsiteMiddleware: 500,
                     TrackSeedsSpiderMiddleware: 550,
                     CrawlingLogsMiddleware: 1000,

--- a/zyte_spider_templates/_addon.py
+++ b/zyte_spider_templates/_addon.py
@@ -151,7 +151,7 @@ class Addon:
                 OffsiteMiddleware,
             )
 
-            _setdefault(settings, "SPIDER_MIDDLEWARES", OffsiteMiddleware, 500)
+            # _setdefault(settings, "SPIDER_MIDDLEWARES", OffsiteMiddleware, 500)
             _replace_builtin(
                 settings,
                 "SPIDER_MIDDLEWARES",
@@ -159,7 +159,7 @@ class Addon:
                 AllowOffsiteMiddleware,
             )
         else:
-            _setdefault(settings, "DOWNLOADER_MIDDLEWARES", OffsiteMiddleware, 500)
+            # _setdefault(settings, "DOWNLOADER_MIDDLEWARES", OffsiteMiddleware, 500)
             _replace_builtin(
                 settings,
                 "DOWNLOADER_MIDDLEWARES",

--- a/zyte_spider_templates/_addon.py
+++ b/zyte_spider_templates/_addon.py
@@ -52,11 +52,11 @@ def _replace_builtin(
 
     builtin_entry: Optional[Any] = None
     for _setting_value in (setting_value, settings[f"{setting}_BASE"]):
-        if builtin_cls in setting_value:
+        if builtin_cls in _setting_value:
             builtin_entry = builtin_cls
             pos = _setting_value[builtin_entry]
             break
-        for cls_or_path in setting_value:
+        for cls_or_path in _setting_value:
             if isinstance(cls_or_path, str):
                 _cls = load_object(cls_or_path)
                 if _cls == builtin_cls:
@@ -151,7 +151,6 @@ class Addon:
                 OffsiteMiddleware,
             )
 
-            # _setdefault(settings, "SPIDER_MIDDLEWARES", OffsiteMiddleware, 500)
             _replace_builtin(
                 settings,
                 "SPIDER_MIDDLEWARES",
@@ -159,7 +158,6 @@ class Addon:
                 AllowOffsiteMiddleware,
             )
         else:
-            # _setdefault(settings, "DOWNLOADER_MIDDLEWARES", OffsiteMiddleware, 500)
             _replace_builtin(
                 settings,
                 "DOWNLOADER_MIDDLEWARES",


### PR DESCRIPTION
`_replace_builtin` is meant to find a component, disable it, and replace it by another with the same priority value.

However, due to a variable typo I probably made myself, this function was failing to see built-in components (those in the `*_BASE` settings), so they were never disabled, causing the built-in offsite middleware to remain enabled, which in turn caused offsite request to be ignored even if allowed through meta (that only our custom middleware takes into account).