### PR TITLE
Add tests for the articles spider using fake-zyte-api.

### DIFF
--- a/tests/test_ecommerce.py
+++ b/tests/test_ecommerce.py
@@ -1337,7 +1337,7 @@ async def test_extract_product_direct_item(zyte_api_server, ecommerce_website):
 
 
 @deferred_f_from_coro_f
-async def test_extract_jobs_404(zyte_api_server, ecommerce_website):
+async def test_extract_products_404(zyte_api_server, ecommerce_website):
     items = await crawl_fake_zyte_api(
         zyte_api_server,
         EcommerceSpider,

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ deps =
     pytest-cov
     pytest-twisted
     freezegun
-    zyte-test-websites @ git+https://github.com/zytedata/zyte-test-websites@ec1ebb0
-    fake-zyte-api @ git+https://github.com/zytedata/fake-zyte-api@32d2881
+    zyte-test-websites @ git+https://github.com/zytedata/zyte-test-websites@c48564f
+    fake-zyte-api @ git+https://github.com/zytedata/fake-zyte-api@1352eec
 commands =
     py.test \
     --cov-report=html:coverage-html \


### PR DESCRIPTION
These are basic tests, not sure if we can test heuristics in some direct way as the only strategy the spider has (except "direct item") is "full". 
We could add more tests for `HeuristicsArticleNavigationPage` as we already have some in https://github.com/zytedata/zyte-spider-templates/blob/main/tests/pages/test_article_navigation_heuristics.py , though I'm not sure yet if the test website is more useful for that than the existing hardcoded HTML.